### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/xresources
+* @tinted-theming/xresources

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,12 +13,13 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Or the above steps represented in shell commands:
 
 ```shell 
 cd /path/to/base16-xresources/../ # This repos parent dir 
-git clone git@github.com:base16-project/base16-builder-go.git
+git clone git@github.com:tinted-theming/base16-builder-go.git
 cd base16-builder-go
 go build ./base16-builder-go/base16-builder-go \
   -template-dir ../base16-xresources
@@ -45,6 +45,6 @@ base16-builder-go \
 If you have more questions about [base16-builder-go][1], have a look at
 the information on the GitHub page.
 
-[1]: https://github.com/base16-project/base16-builder-go
-[2]: https://github.com/base16-project/base16-schemes
+[1]: https://github.com/tinted-theming/base16-builder-go
+[2]: https://github.com/tinted-theming/base16-schemes
 [3]: .github/workflows/update.yml

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,6 +3,7 @@
 Base16 Xresources is released under the MIT License:
 
 > Copyright (C) 2012 [Chris Kempson](http://chriskempson.com)
+> Copyright (C) 2022 [Tinted Theming](https://github.com/tinted-theming)
 > 
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -1,5 +1,6 @@
 ! Base16 {{scheme-name}}
-! Scheme: {{scheme-author}}
+! Scheme author: {{scheme-author}}
+! Template author: Tinted Theming (https://github.com/tinted-theming)
 
 #define base00 #{{base00-hex}}
 #define base01 #{{base01-hex}}

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,5 +1,6 @@
 ! Base16 {{scheme-name}}
-! Scheme: {{scheme-author}}
+! Scheme author: {{scheme-author}}
+! Template author: Tinted Theming (https://github.com/tinted-theming)
 
 #define base00 #{{base00-hex}}
 #define base01 #{{base01-hex}}


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.