### PR TITLE
Make colors consistent to what's defined in tinted-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ update your theme when running `tinty apply base16-default-dark` (where
    supported-systems = ["base16", "base24"]
    ```
 
+### Loading 256 colors in Urxvt
+
+As noted in the template files, if you are using urxvt, colors beyond 15 might
+not be loaded by default. To fix this, you can use the `urxvt-xresources-256`
+extension available at: `https://github.com/Roliga/urxvt-xresources-256`
+
 ## Contributing
 
 See [CONTRIBUTING.md], which contains building and contributing

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -5,6 +5,7 @@
 #define base00 #{{base00-hex}}
 #define base01 #{{base01-hex}}
 #define base02 #{{base02-hex}}
+#define base03 #{{base03-hex}}
 #define base04 #{{base04-hex}}
 #define base05 #{{base05-hex}}
 #define base06 #{{base06-hex}}
@@ -35,7 +36,7 @@
 *color6:       base0C
 *color7:       base05
 
-*color8:       base02
+*color8:       base03
 *color9:       base08
 *color10:      base0B
 *color11:      base0A

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -5,6 +5,7 @@
 #define base00 #{{base00-hex}}
 #define base01 #{{base01-hex}}
 #define base02 #{{base02-hex}}
+#define base03 #{{base03-hex}}
 #define base04 #{{base04-hex}}
 #define base05 #{{base05-hex}}
 #define base06 #{{base06-hex}}
@@ -41,7 +42,7 @@
 *color6:       base0C
 *color7:       base06
 
-*color8:       base02
+*color8:       base03
 *color9:       base12
 *color10:      base14
 *color11:      base13


### PR DESCRIPTION
While reviewing the template available in the tinted-shell repository, I noticed the definition of the base03 color as shown below:

```
color08="{{base03-hex-r}}/{{base03-hex-g}}/{{base03-hex-b}}" # Base 03 - Bright Black
```

Later, this color is assigned in the following manner:

```
put_template 8  "$color08"
```

This modification ensures consistency for users who utilize both tinted-xresources and tinted-shell to set their terminal theme.

Definition in xresources template was missing for some reason:
```
#define base03 #{{base03-hex}}
```

Assign base03 instead of base02 to color8:
```
*color8:       base03
```

Additionally, I have included a reference to the extension that allows urxvt to read the entire 256-color space using xresources in README file.